### PR TITLE
chore: add tsconfig.tsbuildinfo to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # testing
 /coverage
 
+# typescript
+*.tsbuildinfo
+
 # next.js
 /.next/
 /out/


### PR DESCRIPTION
## Summary
- Add `*.tsbuildinfo` to `.gitignore` under a new `# typescript` section to prevent TypeScript incremental build cache files from being tracked in version control.

## Test plan
- [ ] Verify `tsconfig.tsbuildinfo` is no longer shown in `git status` as an untracked file
- [ ] Verify the `.gitignore` file has the new `# typescript` section placed correctly after the `# testing` section