### PR TITLE
refactor: extract reusable components and page data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
+        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "next": "^15.3.3",
         "react": "^19.1.0",
@@ -4138,6 +4139,18 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -5531,7 +5544,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "verify": "npx tsc --noEmit && next lint && npm run build && vitest run"
   },
   "dependencies": {
+    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "next": "^15.3.3",
     "react": "^19.1.0",

--- a/src/app/documentation/page.tsx
+++ b/src/app/documentation/page.tsx
@@ -1,6 +1,11 @@
 import type { Metadata } from 'next';
 import Image from 'next/image';
 
+import { Card } from '@/components/card';
+import { PageHeader } from '@/components/page-header';
+import { SectionHeader } from '@/components/section-header';
+import { capabilities, fileFormats, modules, steps } from '@/data/documentation';
+
 export const metadata: Metadata = {
   title: 'Documentation',
   description:
@@ -8,361 +13,222 @@ export const metadata: Metadata = {
   alternates: { canonical: '/documentation' },
 };
 
-const steps = [
-  {
-    number: 1,
-    title: 'Import your files',
-    description:
-      'Import powder patterns and crystal structures. Supported formats: *.raw, *.rd, *.ard, *.cpi, *.dat, *.dbw, *.gsas, *.mdi, *.rig, *.udf, *.uxd, *.xda, *.xdd, *.xy, ShelX (*.ins, *.res), CIF (*.cif).',
-    image: '/manual/help1.jpg',
-  },
-  {
-    number: 2,
-    title: 'Adjust visibility',
-    description:
-      'Change visibility of patterns and perform all necessary comparisons between experimental and simulated data.',
-    image: '/manual/help2.jpg',
-  },
-  {
-    number: 3,
-    title: 'Customize properties',
-    description:
-      'Fine-tune 2-theta range, FWHM of profiles, and curve colors. Adjust grids, axis labels, and work area properties.',
-    image: '/manual/help3.jpg',
-  },
-  {
-    number: 4,
-    title: 'Export your results',
-    description:
-      'Copy the image to clipboard or export to WMF format for publication-quality figures.',
-    image: '/manual/help4.jpg',
-  },
-];
-
-const fileFormats = [
-  {
-    category: 'Powder Patterns',
-    formats: 'RAW, RD, ARD, CPI, DAT, DBW, GSAS, MDI, RIG, UDF, UXD, XDA, XDD, XY',
-  },
-  { category: 'Crystal Structures', formats: 'ShelX (INS, RES), CIF' },
-];
-
-const capabilities = [
-  {
-    text: 'Multiple powder pattern and molecule import',
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-        <polyline points="14 2 14 8 20 8" />
-      </svg>
-    ),
-  },
-  {
-    text: 'Powder pattern simulation from single crystal data',
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-        <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
-      </svg>
-    ),
-  },
-  {
-    text: 'Background subtraction, smoothing, and scaling',
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-        <line x1="4" y1="21" x2="4" y2="14" /><line x1="4" y1="10" x2="4" y2="3" />
-        <line x1="12" y1="21" x2="12" y2="12" /><line x1="12" y1="8" x2="12" y2="3" />
-        <line x1="20" y1="21" x2="20" y2="16" /><line x1="20" y1="12" x2="20" y2="3" />
-        <line x1="1" y1="14" x2="7" y2="14" /><line x1="9" y1="8" x2="15" y2="8" />
-        <line x1="17" y1="16" x2="23" y2="16" />
-      </svg>
-    ),
-  },
-  {
-    text: 'Customizable work area (grids, tics, axis labels)',
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-        <rect x="3" y="3" width="7" height="7" /><rect x="14" y="3" width="7" height="7" />
-        <rect x="14" y="14" width="7" height="7" /><rect x="3" y="14" width="7" height="7" />
-      </svg>
-    ),
-  },
-  {
-    text: 'Graph color and style customization',
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-        <circle cx="13.5" cy="6.5" r="2.5" /><circle cx="17.5" cy="10.5" r="2.5" />
-        <circle cx="8.5" cy="7.5" r="2.5" /><circle cx="6.5" cy="12.5" r="2.5" />
-        <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z" />
-      </svg>
-    ),
-  },
-  {
-    text: 'Image export to WMF format',
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-        <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-        <circle cx="8.5" cy="8.5" r="1.5" /><polyline points="21 15 16 10 5 21" />
-      </svg>
-    ),
-  },
-  {
-    text: 'Auto-update and error reporting',
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-        <polyline points="23 4 23 10 17 10" />
-        <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
-      </svg>
-    ),
-  },
-];
-
-const modules = [
-  { name: 'ICSharpCode.Core', description: 'Application core framework' },
-  { name: 'ICSharpCode.AddInManager', description: 'Add-in management' },
-  { name: 'ICSharpCode.SharpZipLib', description: 'Archive support' },
-  { name: 'log4net', description: 'Logging' },
-  { name: 'PowDLL', description: 'Powder pattern import' },
-  { name: 'WeifenLuo.WinFormsUI.Docking', description: 'Window docking' },
-  { name: 'ZedGraph', description: 'Graph rendering' },
-];
-
 export default function DocumentationPage() {
   return (
     <div>
-      <section className="bg-gradient-to-br from-primary to-primary-light py-12 md:py-16">
-        <div className="mx-auto max-w-6xl px-6">
-          <h1 className="mb-2 text-3xl font-bold tracking-tight text-white">Documentation</h1>
-          <p className="text-base text-white/70">
-            Learn how to use DiffractWD for powder diffraction analysis.
-          </p>
-        </div>
-      </section>
+      <PageHeader
+        title="Documentation"
+        description="Learn how to use DiffractWD for powder diffraction analysis."
+      />
 
       <div className="mx-auto max-w-6xl px-6 py-14 md:py-16">
-
-      {/* Quick Start */}
-      <section className="mb-20">
-        <div className="mb-8 flex items-center gap-3">
-          <div className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary dark:bg-accent/10 dark:text-accent-light">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-              <polygon points="5 3 19 12 5 21 5 3" />
-            </svg>
-          </div>
-          <h2 className="text-2xl font-bold tracking-tight text-heading dark:text-dark-text">
-            Quick Start
-          </h2>
-        </div>
-        <div className="space-y-6">
-          {steps.map((step) => (
-            <div
-              key={step.number}
-              className="flex flex-col gap-6 rounded-xl border border-border bg-white p-6 md:flex-row dark:border-dark-border dark:bg-dark-surface"
-            >
-              <div className="flex-shrink-0">
-                <Image
-                  src={step.image}
-                  alt={`Step ${step.number}: ${step.title}`}
-                  width={320}
-                  height={224}
-                  className="rounded-lg border border-border dark:border-dark-border"
-                />
-              </div>
-              <div className="flex flex-col justify-start">
-                <div className="mb-3">
-                  <span className="mb-2 inline-block text-xs font-semibold uppercase tracking-widest text-primary dark:text-accent-light">
-                    Step {step.number}
-                  </span>
-                  <h3 className="text-lg font-semibold text-heading dark:text-dark-text">
-                    {step.title}
-                  </h3>
+        {/* Quick Start */}
+        <section className="mb-20">
+          <SectionHeader
+            icon={
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+                <polygon points="5 3 19 12 5 21 5 3" />
+              </svg>
+            }
+            title="Quick Start"
+          />
+          <div className="space-y-6">
+            {steps.map((step) => (
+              <Card key={step.number} className="flex flex-col gap-6 md:flex-row">
+                <div className="flex-shrink-0">
+                  <Image
+                    src={step.image}
+                    alt={`Step ${step.number}: ${step.title}`}
+                    width={320}
+                    height={224}
+                    className="rounded-lg border border-border dark:border-dark-border"
+                  />
                 </div>
-                <p className="text-sm leading-relaxed text-muted dark:text-dark-text-secondary">
-                  {step.description}
-                </p>
-              </div>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* File Formats */}
-      <section className="mb-20">
-        <div className="mb-8 flex items-center gap-3">
-          <div className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary dark:bg-accent/10 dark:text-accent-light">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-              <polyline points="14 2 14 8 20 8" />
-            </svg>
-          </div>
-          <h2 className="text-2xl font-bold tracking-tight text-heading dark:text-dark-text">
-            Supported File Formats
-          </h2>
-        </div>
-        <div className="overflow-hidden rounded-xl border border-border dark:border-dark-border">
-          <table className="w-full text-left text-sm">
-            <thead className="bg-primary/5 dark:bg-dark-surface-alt">
-              <tr>
-                <th className="px-6 py-3.5 text-xs font-semibold uppercase tracking-wider text-primary/70 dark:text-dark-text-secondary">
-                  Category
-                </th>
-                <th className="px-6 py-3.5 text-xs font-semibold uppercase tracking-wider text-primary/70 dark:text-dark-text-secondary">
-                  Formats
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {fileFormats.map((row) => (
-                <tr
-                  key={row.category}
-                  className="border-t border-border dark:border-dark-border"
-                >
-                  <td className="px-6 py-3.5 font-medium text-heading dark:text-dark-text">
-                    {row.category}
-                  </td>
-                  <td className="px-6 py-3.5 text-muted dark:text-dark-text-secondary">
-                    {row.formats}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
-
-      {/* Capabilities */}
-      <section className="mb-20">
-        <div className="mb-8 flex items-center gap-3">
-          <div className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary dark:bg-accent/10 dark:text-accent-light">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-              <polyline points="9 11 12 14 22 4" />
-              <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
-            </svg>
-          </div>
-          <h2 className="text-2xl font-bold tracking-tight text-heading dark:text-dark-text">
-            Capabilities
-          </h2>
-        </div>
-        <div className="grid gap-4 sm:grid-cols-2">
-          {capabilities.map((cap) => (
-            <div
-              key={cap.text}
-              className="flex items-start gap-3 rounded-xl border border-border bg-white p-4 dark:border-dark-border dark:bg-dark-surface"
-            >
-              <div className="mt-0.5 flex-shrink-0 text-primary dark:text-accent-light">
-                {cap.icon}
-              </div>
-              <span className="text-sm text-body dark:text-dark-text">{cap.text}</span>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* System & Technical */}
-      <div className="mb-20 grid gap-6 md:grid-cols-2">
-        <section>
-          <div className="mb-4 flex items-center gap-3">
-            <div className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary dark:bg-accent/10 dark:text-accent-light">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-                <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
-                <line x1="8" y1="21" x2="16" y2="21" /><line x1="12" y1="17" x2="12" y2="21" />
-              </svg>
-            </div>
-            <h2 className="text-xl font-bold text-heading dark:text-dark-text">
-              System Requirements
-            </h2>
-          </div>
-          <div className="rounded-xl border border-border bg-white p-5 dark:border-dark-border dark:bg-dark-surface">
-            <ul className="space-y-3 text-sm text-body dark:text-dark-text">
-              <li className="flex items-center gap-2">
-                <span className="text-primary dark:text-accent-light">&#8226;</span>
-                Windows XP, Vista, or Windows 7
-              </li>
-              <li className="flex items-center gap-2">
-                <span className="text-primary dark:text-accent-light">&#8226;</span>
-                Microsoft .NET Framework 2.0
-              </li>
-            </ul>
+                <div className="flex flex-col justify-start">
+                  <div className="mb-3">
+                    <span className="mb-2 inline-block text-xs font-semibold uppercase tracking-widest text-primary dark:text-accent-light">
+                      Step {step.number}
+                    </span>
+                    <h3 className="text-lg font-semibold text-heading dark:text-dark-text">
+                      {step.title}
+                    </h3>
+                  </div>
+                  <p className="text-sm leading-relaxed text-muted dark:text-dark-text-secondary">
+                    {step.description}
+                  </p>
+                </div>
+              </Card>
+            ))}
           </div>
         </section>
 
-        <section>
-          <div className="mb-4 flex items-center gap-3">
-            <div className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary dark:bg-accent/10 dark:text-accent-light">
+        {/* File Formats */}
+        <section className="mb-20">
+          <SectionHeader
+            icon={
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-                <polyline points="16 18 22 12 16 6" /><polyline points="8 6 2 12 8 18" />
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                <polyline points="14 2 14 8 20 8" />
               </svg>
-            </div>
-            <h2 className="text-xl font-bold text-heading dark:text-dark-text">
-              Technical Details
-            </h2>
-          </div>
-          <div className="rounded-xl border border-border bg-white p-5 dark:border-dark-border dark:bg-dark-surface">
-            <ul className="space-y-3 text-sm text-body dark:text-dark-text">
-              <li className="flex items-center gap-2">
-                <span className="text-primary dark:text-accent-light">&#8226;</span>
-                Written in C# (object-oriented)
-              </li>
-              <li className="flex items-center gap-2">
-                <span className="text-primary dark:text-accent-light">&#8226;</span>
-                Built on SharpDevelop application core
-              </li>
-              <li className="flex items-center gap-2">
-                <span className="text-primary dark:text-accent-light">&#8226;</span>
-                Extensible through add-in system
-              </li>
-              <li className="flex items-center gap-2">
-                <span className="text-primary dark:text-accent-light">&#8226;</span>
-                MIT License
-              </li>
-            </ul>
+            }
+            title="Supported File Formats"
+          />
+          <div className="overflow-hidden rounded-xl border border-border dark:border-dark-border">
+            <table className="w-full text-left text-sm">
+              <thead className="bg-primary/5 dark:bg-dark-surface-alt">
+                <tr>
+                  <th className="px-6 py-3.5 text-xs font-semibold uppercase tracking-wider text-primary/70 dark:text-dark-text-secondary">
+                    Category
+                  </th>
+                  <th className="px-6 py-3.5 text-xs font-semibold uppercase tracking-wider text-primary/70 dark:text-dark-text-secondary">
+                    Formats
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {fileFormats.map((row) => (
+                  <tr
+                    key={row.category}
+                    className="border-t border-border dark:border-dark-border"
+                  >
+                    <td className="px-6 py-3.5 font-medium text-heading dark:text-dark-text">
+                      {row.category}
+                    </td>
+                    <td className="px-6 py-3.5 text-muted dark:text-dark-text-secondary">
+                      {row.formats}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         </section>
-      </div>
 
-      {/* Modules */}
-      <section>
-        <div className="mb-8 flex items-center gap-3">
-          <div className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary dark:bg-accent/10 dark:text-accent-light">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-              <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
-              <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
-              <line x1="12" y1="22.08" x2="12" y2="12" />
-            </svg>
+        {/* Capabilities */}
+        <section className="mb-20">
+          <SectionHeader
+            icon={
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+                <polyline points="9 11 12 14 22 4" />
+                <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
+              </svg>
+            }
+            title="Capabilities"
+          />
+          <div className="grid gap-4 sm:grid-cols-2">
+            {capabilities.map((cap) => (
+              <Card key={cap.text} padding="tight" className="flex items-start gap-3">
+                <div className="mt-0.5 flex-shrink-0 text-primary dark:text-accent-light">
+                  {cap.icon}
+                </div>
+                <span className="text-sm text-body dark:text-dark-text">{cap.text}</span>
+              </Card>
+            ))}
           </div>
-          <h2 className="text-2xl font-bold tracking-tight text-heading dark:text-dark-text">
-            Included Modules
-          </h2>
+        </section>
+
+        {/* System & Technical */}
+        <div className="mb-20 grid gap-6 md:grid-cols-2">
+          <section>
+            <SectionHeader
+              size="md"
+              icon={
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+                  <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+                  <line x1="8" y1="21" x2="16" y2="21" /><line x1="12" y1="17" x2="12" y2="21" />
+                </svg>
+              }
+              title="System Requirements"
+            />
+            <Card padding="compact">
+              <ul className="space-y-3 text-sm text-body dark:text-dark-text">
+                <li className="flex items-center gap-2">
+                  <span className="text-primary dark:text-accent-light">&#8226;</span>
+                  Windows XP, Vista, or Windows 7
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="text-primary dark:text-accent-light">&#8226;</span>
+                  Microsoft .NET Framework 2.0
+                </li>
+              </ul>
+            </Card>
+          </section>
+
+          <section>
+            <SectionHeader
+              size="md"
+              icon={
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+                  <polyline points="16 18 22 12 16 6" /><polyline points="8 6 2 12 8 18" />
+                </svg>
+              }
+              title="Technical Details"
+            />
+            <Card padding="compact">
+              <ul className="space-y-3 text-sm text-body dark:text-dark-text">
+                <li className="flex items-center gap-2">
+                  <span className="text-primary dark:text-accent-light">&#8226;</span>
+                  Written in C# (object-oriented)
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="text-primary dark:text-accent-light">&#8226;</span>
+                  Built on SharpDevelop application core
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="text-primary dark:text-accent-light">&#8226;</span>
+                  Extensible through add-in system
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="text-primary dark:text-accent-light">&#8226;</span>
+                  MIT License
+                </li>
+              </ul>
+            </Card>
+          </section>
         </div>
-        <div className="overflow-hidden rounded-xl border border-border dark:border-dark-border">
-          <table className="w-full text-left text-sm">
-            <thead className="bg-primary/5 dark:bg-dark-surface-alt">
-              <tr>
-                <th className="px-6 py-3.5 text-xs font-semibold uppercase tracking-wider text-primary/70 dark:text-dark-text-secondary">
-                  Module
-                </th>
-                <th className="px-6 py-3.5 text-xs font-semibold uppercase tracking-wider text-primary/70 dark:text-dark-text-secondary">
-                  Purpose
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {modules.map((mod) => (
-                <tr
-                  key={mod.name}
-                  className="border-t border-border dark:border-dark-border"
-                >
-                  <td className="px-6 py-3.5 font-mono text-xs text-heading dark:text-dark-text">
-                    {mod.name}
-                  </td>
-                  <td className="px-6 py-3.5 text-muted dark:text-dark-text-secondary">
-                    {mod.description}
-                  </td>
+
+        {/* Modules */}
+        <section>
+          <SectionHeader
+            icon={
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+                <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+                <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
+                <line x1="12" y1="22.08" x2="12" y2="12" />
+              </svg>
+            }
+            title="Included Modules"
+          />
+          <div className="overflow-hidden rounded-xl border border-border dark:border-dark-border">
+            <table className="w-full text-left text-sm">
+              <thead className="bg-primary/5 dark:bg-dark-surface-alt">
+                <tr>
+                  <th className="px-6 py-3.5 text-xs font-semibold uppercase tracking-wider text-primary/70 dark:text-dark-text-secondary">
+                    Module
+                  </th>
+                  <th className="px-6 py-3.5 text-xs font-semibold uppercase tracking-wider text-primary/70 dark:text-dark-text-secondary">
+                    Purpose
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
+              </thead>
+              <tbody>
+                {modules.map((mod) => (
+                  <tr
+                    key={mod.name}
+                    className="border-t border-border dark:border-dark-border"
+                  >
+                    <td className="px-6 py-3.5 font-mono text-xs text-heading dark:text-dark-text">
+                      {mod.name}
+                    </td>
+                    <td className="px-6 py-3.5 text-muted dark:text-dark-text-secondary">
+                      {mod.description}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/src/app/downloads/page.tsx
+++ b/src/app/downloads/page.tsx
@@ -1,6 +1,13 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
+import { Card, cardVariants } from '@/components/card';
+import { IconContainer } from '@/components/icon-container';
+import { PageHeader } from '@/components/page-header';
+import { SectionHeader } from '@/components/section-header';
+import { cn } from '@/lib/cn';
+import { downloads } from '@/data/downloads';
+
 export const metadata: Metadata = {
   title: 'Downloads',
   description:
@@ -8,138 +15,89 @@ export const metadata: Metadata = {
   alternates: { canonical: '/downloads' },
 };
 
-const downloads = [
-  {
-    title: 'Installation Program',
-    description: 'Recommended. Includes installer with all dependencies.',
-    href: '/downloads/diffractwd.exe',
-    type: 'EXE',
-    recommended: true,
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-7 w-7">
-        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-        <polyline points="7 10 12 15 17 10" />
-        <line x1="12" y1="15" x2="12" y2="3" />
-      </svg>
-    ),
-  },
-  {
-    title: 'Compressed Binaries',
-    description: 'Portable version. Extract and run without installation.',
-    href: '/downloads/diffractwd_bin.zip',
-    type: 'ZIP',
-    recommended: false,
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-7 w-7">
-        <path d="M21 8v13H3V8" />
-        <path d="M1 3h22v5H1z" />
-        <path d="M10 12h4" />
-      </svg>
-    ),
-  },
-  {
-    title: 'Source Code',
-    description: 'Full C# source code. Build with Visual Studio or SharpDevelop.',
-    href: '/downloads/diffractwd_src.zip',
-    type: 'ZIP',
-    recommended: false,
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-7 w-7">
-        <polyline points="16 18 22 12 16 6" />
-        <polyline points="8 6 2 12 8 18" />
-      </svg>
-    ),
-  },
-];
-
 export default function DownloadsPage() {
   return (
     <div>
-      <section className="bg-gradient-to-br from-primary to-primary-light py-12 md:py-16">
-        <div className="mx-auto max-w-6xl px-6">
-          <h1 className="mb-2 text-3xl font-bold tracking-tight text-white">Downloads</h1>
-          <p className="text-base text-white/70">
-            DiffractWD v1.30 — choose the package that works best for you.
-          </p>
-        </div>
-      </section>
+      <PageHeader
+        title="Downloads"
+        description="DiffractWD v1.30 — choose the package that works best for you."
+      />
 
       <div className="mx-auto max-w-6xl px-6 py-14 md:py-16">
-
-      <div className="mb-16 grid gap-5 sm:grid-cols-3">
-        {downloads.map((dl) => (
-          <a
-            key={dl.title}
-            href={dl.href}
-            className="group relative rounded-xl border border-border bg-white p-6 transition-all hover:border-primary/40 hover:shadow-lg dark:border-dark-border dark:bg-dark-surface dark:hover:border-accent-light/30"
-          >
-            {dl.recommended && (
-              <span className="absolute -top-2.5 right-4 rounded-full bg-primary px-3 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-white dark:bg-accent">
-                Recommended
-              </span>
-            )}
-            <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10 text-primary dark:bg-accent/10 dark:text-accent-light">
-              {dl.icon}
-            </div>
-            <div className="mb-3 inline-block rounded-md bg-primary/6 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-primary/60 dark:bg-dark-surface-alt dark:text-dark-text-secondary">
-              {dl.type}
-            </div>
-            <h3 className="mb-1.5 text-base font-semibold text-heading transition-colors group-hover:text-primary dark:text-dark-text dark:group-hover:text-accent-light">
-              {dl.title}
-            </h3>
-            <p className="text-sm leading-relaxed text-muted dark:text-dark-text-secondary">
-              {dl.description}
-            </p>
-          </a>
-        ))}
-      </div>
-
-      <div className="grid gap-6 md:grid-cols-2">
-        <div className="rounded-xl border border-border bg-white p-6 dark:border-dark-border dark:bg-dark-surface">
-          <div className="mb-4 flex items-center gap-3">
-            <div className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary dark:bg-accent/10 dark:text-accent-light">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-                <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
-                <line x1="8" y1="21" x2="16" y2="21" /><line x1="12" y1="17" x2="12" y2="21" />
-              </svg>
-            </div>
-            <h2 className="text-lg font-semibold text-heading dark:text-dark-text">
-              System Requirements
-            </h2>
-          </div>
-          <ul className="space-y-2.5 text-sm text-body dark:text-dark-text">
-            <li className="flex items-center gap-2">
-              <span className="text-primary dark:text-accent-light">&#8226;</span>
-              Windows XP, Vista, or Windows 7
-            </li>
-            <li className="flex items-center gap-2">
-              <span className="text-primary dark:text-accent-light">&#8226;</span>
-              Microsoft .NET Framework 2.0
-            </li>
-          </ul>
-        </div>
-        <div className="rounded-xl border border-border bg-white p-6 dark:border-dark-border dark:bg-dark-surface">
-          <div className="mb-4 flex items-center gap-3">
-            <div className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary dark:bg-accent/10 dark:text-accent-light">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-              </svg>
-            </div>
-            <h2 className="text-lg font-semibold text-heading dark:text-dark-text">License</h2>
-          </div>
-          <p className="text-sm leading-relaxed text-body dark:text-dark-text">
-            DiffractWD is free and open source, licensed under the MIT License. See the full
-            license text on the{' '}
-            <Link
-              href="/support"
-              className="font-medium text-accent hover:underline dark:text-accent-light"
+        <div className="mb-16 grid gap-5 sm:grid-cols-3">
+          {downloads.map((dl) => (
+            <a
+              key={dl.title}
+              href={dl.href}
+              className={cn(cardVariants({ hover: 'border' }), 'group relative')}
             >
-              Support
-            </Link>{' '}
-            page.
-          </p>
+              {dl.recommended && (
+                <span className="absolute -top-2.5 right-4 rounded-full bg-primary px-3 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-white dark:bg-accent">
+                  Recommended
+                </span>
+              )}
+              <IconContainer size="lg" className="mb-4 rounded-xl">
+                {dl.icon}
+              </IconContainer>
+              <div className="mb-3 inline-block rounded-md bg-primary/6 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-primary/60 dark:bg-dark-surface-alt dark:text-dark-text-secondary">
+                {dl.type}
+              </div>
+              <h3 className="mb-1.5 text-base font-semibold text-heading transition-colors group-hover:text-primary dark:text-dark-text dark:group-hover:text-accent-light">
+                {dl.title}
+              </h3>
+              <p className="text-sm leading-relaxed text-muted dark:text-dark-text-secondary">
+                {dl.description}
+              </p>
+            </a>
+          ))}
         </div>
-      </div>
+
+        <div className="grid gap-6 md:grid-cols-2">
+          <Card>
+            <SectionHeader
+              size="sm"
+              icon={
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+                  <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+                  <line x1="8" y1="21" x2="16" y2="21" /><line x1="12" y1="17" x2="12" y2="21" />
+                </svg>
+              }
+              title="System Requirements"
+            />
+            <ul className="space-y-2.5 text-sm text-body dark:text-dark-text">
+              <li className="flex items-center gap-2">
+                <span className="text-primary dark:text-accent-light">&#8226;</span>
+                Windows XP, Vista, or Windows 7
+              </li>
+              <li className="flex items-center gap-2">
+                <span className="text-primary dark:text-accent-light">&#8226;</span>
+                Microsoft .NET Framework 2.0
+              </li>
+            </ul>
+          </Card>
+          <Card>
+            <SectionHeader
+              size="sm"
+              icon={
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+                  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+                </svg>
+              }
+              title="License"
+            />
+            <p className="text-sm leading-relaxed text-body dark:text-dark-text">
+              DiffractWD is free and open source, licensed under the MIT License. See the full
+              license text on the{' '}
+              <Link
+                href="/support"
+                className="font-medium text-accent hover:underline dark:text-accent-light"
+              >
+                Support
+              </Link>{' '}
+              page.
+            </p>
+          </Card>
+        </div>
       </div>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,24 +2,13 @@ import type { Metadata } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
 
+import { Card } from '@/components/card';
+import { IconContainer } from '@/components/icon-container';
+import { features, jsonLd, stats } from '@/data/home';
+
 export const metadata: Metadata = {
   title: 'DiffractWD - Free Powder Diffraction Software',
   alternates: { canonical: '/' },
-};
-
-const jsonLd = {
-  '@context': 'https://schema.org',
-  '@type': 'SoftwareApplication',
-  name: 'DiffractWD',
-  applicationCategory: 'ScienceApplication',
-  operatingSystem: 'Windows',
-  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
-  description:
-    'Free open-source software for powder diffraction pattern manipulation, simulation, and visualization.',
-  softwareVersion: '1.30',
-  license: 'https://opensource.org/licenses/MIT',
-  author: { '@type': 'Person', name: 'Volodymyr D. Vreshch' },
-  url: 'https://diffractwd.com',
 };
 
 const DownloadIcon = () => (
@@ -29,8 +18,6 @@ const DownloadIcon = () => (
     <line x1="12" y1="15" x2="12" y2="3" />
   </svg>
 );
-
-/* ─── Buttons ─── */
 
 function HeroButtons() {
   return (
@@ -72,88 +59,6 @@ function CtaButtons() {
   );
 }
 
-/* ─── Data ─── */
-
-const features = [
-  {
-    title: 'Multiple Format Support',
-    description:
-      'Import powder patterns from 14 file formats including RAW, RD, CPI, UXD, XY, and more. Load crystal structures from CIF and ShelX files.',
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
-        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-        <polyline points="14 2 14 8 20 8" />
-        <line x1="16" y1="13" x2="8" y2="13" />
-        <line x1="16" y1="17" x2="8" y2="17" />
-      </svg>
-    ),
-  },
-  {
-    title: 'Pattern Simulation',
-    description:
-      'Simulate powder patterns from single crystal data. Compare experimental and calculated patterns side by side.',
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
-        <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
-      </svg>
-    ),
-  },
-  {
-    title: 'Data Processing',
-    description:
-      'Background subtraction, smoothing, and scaling. Customize 2-theta range, FWHM, and curve colors.',
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
-        <circle cx="12" cy="12" r="3" />
-        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-      </svg>
-    ),
-  },
-  {
-    title: 'Publication Ready',
-    description:
-      'Export graphs as WMF images. Customize grids, axis labels, and graph colors for publication-quality figures.',
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
-        <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-        <circle cx="8.5" cy="8.5" r="1.5" />
-        <polyline points="21 15 16 10 5 21" />
-      </svg>
-    ),
-  },
-  {
-    title: 'Open Source',
-    description:
-      'Written in C# with an extensible add-in system. Licensed under the MIT License. Free to use and modify.',
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
-        <polyline points="16 18 22 12 16 6" />
-        <polyline points="8 6 2 12 8 18" />
-      </svg>
-    ),
-  },
-  {
-    title: 'Auto Updates',
-    description:
-      'Built-in auto-update and error reporting modules keep you on the latest stable version.',
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
-        <polyline points="23 4 23 10 17 10" />
-        <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
-      </svg>
-    ),
-  },
-];
-
-const stats = [
-  { value: '14+', label: 'File Formats' },
-  { value: 'CIF', label: 'Crystal Structures' },
-  { value: 'WMF', label: 'Export Format' },
-  { value: 'MIT', label: 'License' },
-];
-
-/* ─── Page ─── */
-
 export default function HomePage() {
   return (
     <div>
@@ -161,6 +66,7 @@ export default function HomePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
+
       {/* Hero */}
       <section className="relative overflow-hidden bg-gradient-to-br from-primary to-primary-light py-24 md:py-32">
         <div className="mx-auto max-w-6xl px-6">
@@ -229,20 +135,17 @@ export default function HomePage() {
           </div>
           <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
             {features.map((feature) => (
-              <div
-                key={feature.title}
-                className="group rounded-xl border border-border bg-white p-6 shadow-sm transition-all hover:shadow-lg dark:border-dark-border dark:bg-dark-surface dark:shadow-none dark:hover:bg-dark-surface-alt"
-              >
-                <div className="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary dark:bg-accent/10 dark:text-accent-light">
+              <Card key={feature.title} hover="lift" className="group">
+                <IconContainer size="md" className="mb-4">
                   {feature.icon}
-                </div>
+                </IconContainer>
                 <h3 className="mb-2 text-base font-semibold text-heading dark:text-dark-text">
                   {feature.title}
                 </h3>
                 <p className="text-sm leading-relaxed text-muted dark:text-dark-text-secondary">
                   {feature.description}
                 </p>
-              </div>
+              </Card>
             ))}
           </div>
         </div>

--- a/src/app/screenshots/page.tsx
+++ b/src/app/screenshots/page.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from 'next';
+
 import { ScreenshotGallery } from '@/components/lightbox';
+import { PageHeader } from '@/components/page-header';
+import { screenshots } from '@/data/screenshots';
 
 export const metadata: Metadata = {
   title: 'Screenshots',
@@ -7,40 +10,13 @@ export const metadata: Metadata = {
   alternates: { canonical: '/screenshots' },
 };
 
-const screenshots = [
-  {
-    src: '/screenshots/screenshot1_mini.jpg',
-    full: '/screenshots/screenshot1.jpg',
-    title: 'Default Open Window',
-  },
-  {
-    src: '/screenshots/screenshot2_mini.jpg',
-    full: '/screenshots/screenshot2.jpg',
-    title: 'Powder Pattern Import',
-  },
-  {
-    src: '/screenshots/screenshot3_mini.jpg',
-    full: '/screenshots/screenshot3.jpg',
-    title: 'Powder Pattern Simulation',
-  },
-  {
-    src: '/screenshots/screenshot4_mini.jpg',
-    full: '/screenshots/screenshot4.jpg',
-    title: 'Advanced Windows Docking',
-  },
-];
-
 export default function ScreenshotsPage() {
   return (
     <div>
-      <section className="bg-gradient-to-br from-primary to-primary-light py-12 md:py-16">
-        <div className="mx-auto max-w-6xl px-6">
-          <h1 className="mb-2 text-3xl font-bold tracking-tight text-white">Screenshots</h1>
-          <p className="text-base text-white/70">
-            See DiffractWD in action. Click any image to view full size.
-          </p>
-        </div>
-      </section>
+      <PageHeader
+        title="Screenshots"
+        description="See DiffractWD in action. Click any image to view full size."
+      />
 
       <div className="mx-auto max-w-6xl px-6 py-14 md:py-16">
         <ScreenshotGallery screenshots={screenshots} />

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,5 +1,10 @@
 import type { Metadata } from 'next';
 
+import { Card } from '@/components/card';
+import { PageHeader } from '@/components/page-header';
+import { SectionHeader } from '@/components/section-header';
+import { changelog } from '@/data/support';
+
 export const metadata: Metadata = {
   title: 'Support',
   description:
@@ -7,213 +12,149 @@ export const metadata: Metadata = {
   alternates: { canonical: '/support' },
 };
 
-const changelog = [
-  {
-    version: '2.0',
-    date: 'March 2025',
-    changes: [
-      'Website redesigned with modern layout and dark mode',
-      'Consolidated pages for improved navigation',
-      'Responsive design for mobile and desktop',
-    ],
-  },
-  {
-    version: '1.30',
-    date: '28 January 2011',
-    changes: [
-      'Published: V.D. Vreshch, J. App. Cryst., 44, 219-220 (2011)',
-      'Windows Vista and Windows 7 support',
-      'New webpage design',
-      'Bug fixes',
-    ],
-  },
-  {
-    version: '1.20',
-    date: '27 October 2010',
-    changes: [
-      'Background subtraction, smoothing, and scale functions',
-      'Graph navigation improvements',
-      'Powder pattern generation module revision',
-      'Help menu and image export added',
-      'Bug fixes',
-    ],
-  },
-  {
-    version: '1.02',
-    date: '16 June 2010',
-    changes: [
-      'Installation package available',
-      'Native file format support',
-      'Several bug fixes',
-    ],
-  },
-  {
-    version: '1.01',
-    date: '6 June 2010',
-    changes: [
-      'Precompiled package available',
-      'Source code (C#) available for download',
-    ],
-  },
-  {
-    version: '1.00',
-    date: '15 May 2010',
-    changes: ['Initial release to limited number of users'],
-  },
-];
-
 export default function SupportPage() {
   return (
     <div>
-      <section className="bg-gradient-to-br from-primary to-primary-light py-12 md:py-16">
-        <div className="mx-auto max-w-6xl px-6">
-          <h1 className="mb-2 text-3xl font-bold tracking-tight text-white">Support</h1>
-          <p className="text-base text-white/70">
-            Get help, report issues, or review the license.
-          </p>
-        </div>
-      </section>
+      <PageHeader
+        title="Support"
+        description="Get help, report issues, or review the license."
+      />
 
       <div className="mx-auto max-w-6xl px-6 py-14 md:py-16">
+        {/* Author & Feedback */}
+        <div className="mb-20 grid gap-6 md:grid-cols-2">
+          <Card>
+            <SectionHeader
+              size="sm"
+              icon={
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+                  <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                  <circle cx="12" cy="7" r="4" />
+                </svg>
+              }
+              title="Author"
+            />
+            <p className="text-sm text-body dark:text-dark-text">
+              <a
+                href="https://vreshch.com/contacts"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-accent hover:underline dark:text-accent-light"
+              >
+                Volodymyr D. Vreshch
+              </a>
+            </p>
+            <p className="mt-2 text-sm text-muted dark:text-dark-text-secondary">
+              Ph.D. in Inorganic Chemistry, Kyiv, Ukraine
+            </p>
+            <p className="mt-1 text-sm text-muted dark:text-dark-text-secondary">
+              Senior Software Engineer at Microsoft
+            </p>
+          </Card>
+          <Card>
+            <SectionHeader
+              size="sm"
+              icon={
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+                  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+                </svg>
+              }
+              title="Feedback"
+            />
+            <p className="mb-3 text-sm text-body dark:text-dark-text">We welcome your input:</p>
+            <ul className="space-y-2 text-sm text-muted dark:text-dark-text-secondary">
+              <li className="flex items-center gap-2">
+                <span className="text-primary dark:text-accent-light">&#8226;</span>
+                Suggestions and feature requests
+              </li>
+              <li className="flex items-center gap-2">
+                <span className="text-primary dark:text-accent-light">&#8226;</span>
+                Bug reports
+              </li>
+              <li className="flex items-center gap-2">
+                <span className="text-primary dark:text-accent-light">&#8226;</span>
+                Questions and help requests
+              </li>
+            </ul>
+          </Card>
+        </div>
 
-      {/* Author & Feedback */}
-      <div className="mb-20 grid gap-6 md:grid-cols-2">
-        <div className="rounded-xl border border-border bg-white p-6 dark:border-dark-border dark:bg-dark-surface">
-          <div className="mb-4 flex items-center gap-3">
-            <div className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary dark:bg-accent/10 dark:text-accent-light">
+        {/* Changelog */}
+        <section className="mb-20">
+          <SectionHeader
+            icon={
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-                <circle cx="12" cy="7" r="4" />
+                <circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" />
               </svg>
-            </div>
-            <h2 className="text-lg font-semibold text-heading dark:text-dark-text">Author</h2>
-          </div>
-          <p className="text-sm text-body dark:text-dark-text">
-            <a
-              href="https://vreshch.com/contacts"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-medium text-accent hover:underline dark:text-accent-light"
-            >
-              Volodymyr D. Vreshch
-            </a>
-          </p>
-          <p className="mt-2 text-sm text-muted dark:text-dark-text-secondary">
-            Ph.D. in Inorganic Chemistry, Kyiv, Ukraine
-          </p>
-          <p className="mt-1 text-sm text-muted dark:text-dark-text-secondary">
-            Senior Software Engineer at Microsoft
-          </p>
-        </div>
-        <div className="rounded-xl border border-border bg-white p-6 dark:border-dark-border dark:bg-dark-surface">
-          <div className="mb-4 flex items-center gap-3">
-            <div className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary dark:bg-accent/10 dark:text-accent-light">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-              </svg>
-            </div>
-            <h2 className="text-lg font-semibold text-heading dark:text-dark-text">Feedback</h2>
-          </div>
-          <p className="mb-3 text-sm text-body dark:text-dark-text">We welcome your input:</p>
-          <ul className="space-y-2 text-sm text-muted dark:text-dark-text-secondary">
-            <li className="flex items-center gap-2">
-              <span className="text-primary dark:text-accent-light">&#8226;</span>
-              Suggestions and feature requests
-            </li>
-            <li className="flex items-center gap-2">
-              <span className="text-primary dark:text-accent-light">&#8226;</span>
-              Bug reports
-            </li>
-            <li className="flex items-center gap-2">
-              <span className="text-primary dark:text-accent-light">&#8226;</span>
-              Questions and help requests
-            </li>
-          </ul>
-        </div>
-      </div>
-
-      {/* Changelog */}
-      <section className="mb-20">
-        <div className="mb-8 flex items-center gap-3">
-          <div className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary dark:bg-accent/10 dark:text-accent-light">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-              <circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" />
-            </svg>
-          </div>
-          <h2 className="text-2xl font-bold tracking-tight text-heading dark:text-dark-text">
-            Changelog
-          </h2>
-        </div>
-        <div className="relative space-y-4">
-          {/* Timeline line */}
-          <div className="absolute left-[4px] top-8 hidden h-[calc(100%-48px)] w-px bg-border dark:bg-dark-border md:block" />
-          {changelog.map((release, idx) => (
-            <div key={release.version} className="relative flex gap-5">
-              {/* Timeline dot */}
-              <div className="relative hidden w-[9px] flex-shrink-0 md:block">
-                <div className={`mt-[22px] h-[9px] w-[9px] rounded-full ring-2 ring-white dark:ring-dark-bg ${idx === 0 ? 'bg-primary dark:bg-accent-light' : 'bg-border dark:bg-dark-border'}`} />
-              </div>
-              <div className="flex-1 rounded-xl border border-border bg-white p-5 dark:border-dark-border dark:bg-dark-surface">
-                <div className="mb-3 flex flex-wrap items-baseline gap-3">
-                  <span className={`inline-block rounded-md px-2.5 py-0.5 text-xs font-semibold ${idx === 0 ? 'bg-primary/10 text-primary dark:bg-accent/10 dark:text-accent-light' : 'bg-primary/5 text-primary/60 dark:bg-dark-surface-alt dark:text-dark-text-secondary'}`}>
-                    v{release.version}
-                  </span>
-                  <span className="text-sm text-muted dark:text-dark-text-secondary">
-                    {release.date}
-                  </span>
+            }
+            title="Changelog"
+          />
+          <div className="relative space-y-4">
+            <div className="absolute left-[4px] top-8 hidden h-[calc(100%-48px)] w-px bg-border dark:bg-dark-border md:block" />
+            {changelog.map((release, idx) => (
+              <div key={release.version} className="relative flex gap-5">
+                <div className="relative hidden w-[9px] flex-shrink-0 md:block">
+                  <div className={`mt-[22px] h-[9px] w-[9px] rounded-full ring-2 ring-white dark:ring-dark-bg ${idx === 0 ? 'bg-primary dark:bg-accent-light' : 'bg-border dark:bg-dark-border'}`} />
                 </div>
-                <ul className="space-y-1.5 text-sm text-body dark:text-dark-text">
-                  {release.changes.map((change, i) => (
-                    <li key={i} className="flex items-start gap-2">
-                      <span className="mt-1.5 h-1 w-1 flex-shrink-0 rounded-full bg-muted dark:bg-dark-text-secondary" />
-                      {change}
-                    </li>
-                  ))}
-                </ul>
+                <Card padding="compact" className="flex-1">
+                  <div className="mb-3 flex flex-wrap items-baseline gap-3">
+                    <span className={`inline-block rounded-md px-2.5 py-0.5 text-xs font-semibold ${idx === 0 ? 'bg-primary/10 text-primary dark:bg-accent/10 dark:text-accent-light' : 'bg-primary/5 text-primary/60 dark:bg-dark-surface-alt dark:text-dark-text-secondary'}`}>
+                      v{release.version}
+                    </span>
+                    <span className="text-sm text-muted dark:text-dark-text-secondary">
+                      {release.date}
+                    </span>
+                  </div>
+                  <ul className="space-y-1.5 text-sm text-body dark:text-dark-text">
+                    {release.changes.map((change, i) => (
+                      <li key={i} className="flex items-start gap-2">
+                        <span className="mt-1.5 h-1 w-1 flex-shrink-0 rounded-full bg-muted dark:bg-dark-text-secondary" />
+                        {change}
+                      </li>
+                    ))}
+                  </ul>
+                </Card>
               </div>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* License */}
-      <section>
-        <div className="mb-8 flex items-center gap-3">
-          <div className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary dark:bg-accent/10 dark:text-accent-light">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-              <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-            </svg>
+            ))}
           </div>
-          <h2 className="text-2xl font-bold tracking-tight text-heading dark:text-dark-text">
-            MIT License
-          </h2>
-        </div>
-        <div className="rounded-xl border border-border bg-surface p-6 text-sm leading-relaxed text-body dark:border-dark-border dark:bg-dark-surface dark:text-dark-text">
-          <p className="mb-4 font-medium">
-            Copyright {new Date().getFullYear()} Volodymyr D. Vreshch
-          </p>
-          <p className="mb-4">
-            Permission is hereby granted, free of charge, to any person obtaining a copy of this
-            software and associated documentation files (the &quot;Software&quot;), to deal in the
-            Software without restriction, including without limitation the rights to use, copy,
-            modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
-            to permit persons to whom the Software is furnished to do so, subject to the following
-            conditions:
-          </p>
-          <p className="mb-4">
-            The above copyright notice and this permission notice shall be included in all copies or
-            substantial portions of the Software.
-          </p>
-          <p className="text-xs text-muted dark:text-dark-text-secondary">
-            THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-            IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-            PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-            HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
-            CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
-            THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-          </p>
-        </div>
-      </section>
+        </section>
+
+        {/* License */}
+        <section>
+          <SectionHeader
+            icon={
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+              </svg>
+            }
+            title="MIT License"
+          />
+          <Card className="bg-surface text-sm leading-relaxed text-body dark:text-dark-text">
+            <p className="mb-4 font-medium">
+              Copyright {new Date().getFullYear()} Volodymyr D. Vreshch
+            </p>
+            <p className="mb-4">
+              Permission is hereby granted, free of charge, to any person obtaining a copy of this
+              software and associated documentation files (the &quot;Software&quot;), to deal in the
+              Software without restriction, including without limitation the rights to use, copy,
+              modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+              to permit persons to whom the Software is furnished to do so, subject to the following
+              conditions:
+            </p>
+            <p className="mb-4">
+              The above copyright notice and this permission notice shall be included in all copies or
+              substantial portions of the Software.
+            </p>
+            <p className="text-xs text-muted dark:text-dark-text-secondary">
+              THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+              IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+              PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+              HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+              CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
+              THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+            </p>
+          </Card>
+        </section>
       </div>
     </div>
   );

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -1,0 +1,37 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { ReactNode } from 'react';
+
+import { cn } from '@/lib/cn';
+
+export const cardVariants = cva(
+  'rounded-xl border border-border bg-white dark:border-dark-border dark:bg-dark-surface',
+  {
+    variants: {
+      padding: {
+        none: '',
+        tight: 'p-4',
+        compact: 'p-5',
+        default: 'p-6',
+      },
+      hover: {
+        none: '',
+        lift: 'shadow-sm transition-all hover:shadow-lg dark:shadow-none dark:hover:bg-dark-surface-alt',
+        border:
+          'transition-all hover:border-primary/40 hover:shadow-lg dark:hover:border-accent-light/30',
+      },
+    },
+    defaultVariants: {
+      padding: 'default',
+      hover: 'none',
+    },
+  }
+);
+
+type CardProps = VariantProps<typeof cardVariants> & {
+  children: ReactNode;
+  className?: string;
+};
+
+export function Card({ children, className, padding, hover }: CardProps) {
+  return <div className={cn(cardVariants({ padding, hover }), className)}>{children}</div>;
+}

--- a/src/components/icon-container.tsx
+++ b/src/components/icon-container.tsx
@@ -1,0 +1,29 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { ReactNode } from 'react';
+
+import { cn } from '@/lib/cn';
+
+const iconContainerVariants = cva(
+  'inline-flex items-center justify-center rounded-lg bg-primary/10 text-primary dark:bg-accent/10 dark:text-accent-light',
+  {
+    variants: {
+      size: {
+        sm: 'h-8 w-8',
+        md: 'h-10 w-10',
+        lg: 'h-12 w-12',
+      },
+    },
+    defaultVariants: {
+      size: 'sm',
+    },
+  }
+);
+
+type IconContainerProps = VariantProps<typeof iconContainerVariants> & {
+  children: ReactNode;
+  className?: string;
+};
+
+export function IconContainer({ children, className, size }: IconContainerProps) {
+  return <div className={cn(iconContainerVariants({ size }), className)}>{children}</div>;
+}

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -1,0 +1,10 @@
+export function PageHeader({ title, description }: { title: string; description: string }) {
+  return (
+    <section className="bg-gradient-to-br from-primary to-primary-light py-12 md:py-16">
+      <div className="mx-auto max-w-6xl px-6">
+        <h1 className="mb-2 text-3xl font-bold tracking-tight text-white">{title}</h1>
+        <p className="text-base text-white/70">{description}</p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/section-header.tsx
+++ b/src/components/section-header.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+
+import { cn } from '@/lib/cn';
+import { IconContainer } from '@/components/icon-container';
+
+const styles = {
+  sm: { margin: 'mb-4', heading: 'text-lg font-semibold' },
+  md: { margin: 'mb-4', heading: 'text-xl font-bold' },
+  lg: { margin: 'mb-8', heading: 'text-2xl font-bold tracking-tight' },
+} as const;
+
+type SectionHeaderProps = {
+  icon: ReactNode;
+  title: string;
+  size?: keyof typeof styles;
+};
+
+export function SectionHeader({ icon, title, size = 'lg' }: SectionHeaderProps) {
+  const { margin, heading } = styles[size];
+  return (
+    <div className={cn(margin, 'flex items-center gap-3')}>
+      <IconContainer>{icon}</IconContainer>
+      <h2 className={cn(heading, 'text-heading dark:text-dark-text')}>{title}</h2>
+    </div>
+  );
+}

--- a/src/data/documentation.tsx
+++ b/src/data/documentation.tsx
@@ -1,0 +1,124 @@
+import type { ReactNode } from 'react';
+
+export const steps = [
+  {
+    number: 1,
+    title: 'Import your files',
+    description:
+      'Import powder patterns and crystal structures. Supported formats: *.raw, *.rd, *.ard, *.cpi, *.dat, *.dbw, *.gsas, *.mdi, *.rig, *.udf, *.uxd, *.xda, *.xdd, *.xy, ShelX (*.ins, *.res), CIF (*.cif).',
+    image: '/manual/help1.jpg',
+  },
+  {
+    number: 2,
+    title: 'Adjust visibility',
+    description:
+      'Change visibility of patterns and perform all necessary comparisons between experimental and simulated data.',
+    image: '/manual/help2.jpg',
+  },
+  {
+    number: 3,
+    title: 'Customize properties',
+    description:
+      'Fine-tune 2-theta range, FWHM of profiles, and curve colors. Adjust grids, axis labels, and work area properties.',
+    image: '/manual/help3.jpg',
+  },
+  {
+    number: 4,
+    title: 'Export your results',
+    description:
+      'Copy the image to clipboard or export to WMF format for publication-quality figures.',
+    image: '/manual/help4.jpg',
+  },
+];
+
+export const fileFormats = [
+  {
+    category: 'Powder Patterns',
+    formats: 'RAW, RD, ARD, CPI, DAT, DBW, GSAS, MDI, RIG, UDF, UXD, XDA, XDD, XY',
+  },
+  { category: 'Crystal Structures', formats: 'ShelX (INS, RES), CIF' },
+];
+
+export interface Capability {
+  text: string;
+  icon: ReactNode;
+}
+
+export const capabilities: Capability[] = [
+  {
+    text: 'Multiple powder pattern and molecule import',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+        <polyline points="14 2 14 8 20 8" />
+      </svg>
+    ),
+  },
+  {
+    text: 'Powder pattern simulation from single crystal data',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+        <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+      </svg>
+    ),
+  },
+  {
+    text: 'Background subtraction, smoothing, and scaling',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+        <line x1="4" y1="21" x2="4" y2="14" /><line x1="4" y1="10" x2="4" y2="3" />
+        <line x1="12" y1="21" x2="12" y2="12" /><line x1="12" y1="8" x2="12" y2="3" />
+        <line x1="20" y1="21" x2="20" y2="16" /><line x1="20" y1="12" x2="20" y2="3" />
+        <line x1="1" y1="14" x2="7" y2="14" /><line x1="9" y1="8" x2="15" y2="8" />
+        <line x1="17" y1="16" x2="23" y2="16" />
+      </svg>
+    ),
+  },
+  {
+    text: 'Customizable work area (grids, tics, axis labels)',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+        <rect x="3" y="3" width="7" height="7" /><rect x="14" y="3" width="7" height="7" />
+        <rect x="14" y="14" width="7" height="7" /><rect x="3" y="14" width="7" height="7" />
+      </svg>
+    ),
+  },
+  {
+    text: 'Graph color and style customization',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+        <circle cx="13.5" cy="6.5" r="2.5" /><circle cx="17.5" cy="10.5" r="2.5" />
+        <circle cx="8.5" cy="7.5" r="2.5" /><circle cx="6.5" cy="12.5" r="2.5" />
+        <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z" />
+      </svg>
+    ),
+  },
+  {
+    text: 'Image export to WMF format',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+        <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+        <circle cx="8.5" cy="8.5" r="1.5" /><polyline points="21 15 16 10 5 21" />
+      </svg>
+    ),
+  },
+  {
+    text: 'Auto-update and error reporting',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+        <polyline points="23 4 23 10 17 10" />
+        <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+      </svg>
+    ),
+  },
+];
+
+export const modules = [
+  { name: 'ICSharpCode.Core', description: 'Application core framework' },
+  { name: 'ICSharpCode.AddInManager', description: 'Add-in management' },
+  { name: 'ICSharpCode.SharpZipLib', description: 'Archive support' },
+  { name: 'log4net', description: 'Logging' },
+  { name: 'PowDLL', description: 'Powder pattern import' },
+  { name: 'WeifenLuo.WinFormsUI.Docking', description: 'Window docking' },
+  { name: 'ZedGraph', description: 'Graph rendering' },
+];

--- a/src/data/downloads.tsx
+++ b/src/data/downloads.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from 'react';
+
+export interface DownloadItem {
+  title: string;
+  description: string;
+  href: string;
+  type: string;
+  recommended: boolean;
+  icon: ReactNode;
+}
+
+export const downloads: DownloadItem[] = [
+  {
+    title: 'Installation Program',
+    description: 'Recommended. Includes installer with all dependencies.',
+    href: '/downloads/diffractwd.exe',
+    type: 'EXE',
+    recommended: true,
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-7 w-7">
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+        <polyline points="7 10 12 15 17 10" />
+        <line x1="12" y1="15" x2="12" y2="3" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Compressed Binaries',
+    description: 'Portable version. Extract and run without installation.',
+    href: '/downloads/diffractwd_bin.zip',
+    type: 'ZIP',
+    recommended: false,
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-7 w-7">
+        <path d="M21 8v13H3V8" />
+        <path d="M1 3h22v5H1z" />
+        <path d="M10 12h4" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Source Code',
+    description: 'Full C# source code. Build with Visual Studio or SharpDevelop.',
+    href: '/downloads/diffractwd_src.zip',
+    type: 'ZIP',
+    recommended: false,
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-7 w-7">
+        <polyline points="16 18 22 12 16 6" />
+        <polyline points="8 6 2 12 8 18" />
+      </svg>
+    ),
+  },
+];

--- a/src/data/home.tsx
+++ b/src/data/home.tsx
@@ -1,0 +1,100 @@
+import type { ReactNode } from 'react';
+
+export const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'DiffractWD',
+  applicationCategory: 'ScienceApplication',
+  operatingSystem: 'Windows',
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  description:
+    'Free open-source software for powder diffraction pattern manipulation, simulation, and visualization.',
+  softwareVersion: '1.30',
+  license: 'https://opensource.org/licenses/MIT',
+  author: { '@type': 'Person', name: 'Volodymyr D. Vreshch' },
+  url: 'https://diffractwd.com',
+};
+
+export interface Feature {
+  title: string;
+  description: string;
+  icon: ReactNode;
+}
+
+export const features: Feature[] = [
+  {
+    title: 'Multiple Format Support',
+    description:
+      'Import powder patterns from 14 file formats including RAW, RD, CPI, UXD, XY, and more. Load crystal structures from CIF and ShelX files.',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+        <polyline points="14 2 14 8 20 8" />
+        <line x1="16" y1="13" x2="8" y2="13" />
+        <line x1="16" y1="17" x2="8" y2="17" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Pattern Simulation',
+    description:
+      'Simulate powder patterns from single crystal data. Compare experimental and calculated patterns side by side.',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
+        <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Data Processing',
+    description:
+      'Background subtraction, smoothing, and scaling. Customize 2-theta range, FWHM, and curve colors.',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
+        <circle cx="12" cy="12" r="3" />
+        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Publication Ready',
+    description:
+      'Export graphs as WMF images. Customize grids, axis labels, and graph colors for publication-quality figures.',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
+        <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+        <circle cx="8.5" cy="8.5" r="1.5" />
+        <polyline points="21 15 16 10 5 21" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Open Source',
+    description:
+      'Written in C# with an extensible add-in system. Licensed under the MIT License. Free to use and modify.',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
+        <polyline points="16 18 22 12 16 6" />
+        <polyline points="8 6 2 12 8 18" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Auto Updates',
+    description:
+      'Built-in auto-update and error reporting modules keep you on the latest stable version.',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
+        <polyline points="23 4 23 10 17 10" />
+        <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+      </svg>
+    ),
+  },
+];
+
+export const stats = [
+  { value: '14+', label: 'File Formats' },
+  { value: 'CIF', label: 'Crystal Structures' },
+  { value: 'WMF', label: 'Export Format' },
+  { value: 'MIT', label: 'License' },
+];

--- a/src/data/screenshots.ts
+++ b/src/data/screenshots.ts
@@ -1,0 +1,22 @@
+export const screenshots = [
+  {
+    src: '/screenshots/screenshot1_mini.jpg',
+    full: '/screenshots/screenshot1.jpg',
+    title: 'Default Open Window',
+  },
+  {
+    src: '/screenshots/screenshot2_mini.jpg',
+    full: '/screenshots/screenshot2.jpg',
+    title: 'Powder Pattern Import',
+  },
+  {
+    src: '/screenshots/screenshot3_mini.jpg',
+    full: '/screenshots/screenshot3.jpg',
+    title: 'Powder Pattern Simulation',
+  },
+  {
+    src: '/screenshots/screenshot4_mini.jpg',
+    full: '/screenshots/screenshot4.jpg',
+    title: 'Advanced Windows Docking',
+  },
+];

--- a/src/data/support.ts
+++ b/src/data/support.ts
@@ -1,0 +1,54 @@
+export const changelog = [
+  {
+    version: '2.0',
+    date: 'March 2025',
+    changes: [
+      'Website redesigned with modern layout and dark mode',
+      'Consolidated pages for improved navigation',
+      'Responsive design for mobile and desktop',
+    ],
+  },
+  {
+    version: '1.30',
+    date: '28 January 2011',
+    changes: [
+      'Published: V.D. Vreshch, J. App. Cryst., 44, 219-220 (2011)',
+      'Windows Vista and Windows 7 support',
+      'New webpage design',
+      'Bug fixes',
+    ],
+  },
+  {
+    version: '1.20',
+    date: '27 October 2010',
+    changes: [
+      'Background subtraction, smoothing, and scale functions',
+      'Graph navigation improvements',
+      'Powder pattern generation module revision',
+      'Help menu and image export added',
+      'Bug fixes',
+    ],
+  },
+  {
+    version: '1.02',
+    date: '16 June 2010',
+    changes: [
+      'Installation package available',
+      'Native file format support',
+      'Several bug fixes',
+    ],
+  },
+  {
+    version: '1.01',
+    date: '6 June 2010',
+    changes: [
+      'Precompiled package available',
+      'Source code (C#) available for download',
+    ],
+  },
+  {
+    version: '1.00',
+    date: '15 May 2010',
+    changes: ['Initial release to limited number of users'],
+  },
+];


### PR DESCRIPTION
## Summary
- Extract 4 reusable components: `Card` (CVA variants), `IconContainer`, `PageHeader`, `SectionHeader`
- Move page data arrays to `src/data/` files for separation of concerns
- Add `class-variance-authority` dependency for component variants

## Test plan
- [x] TypeScript type-check passes
- [x] ESLint passes
- [x] All 31 unit tests pass
- [x] Production build succeeds
- [x] Visual regression: verify no UI changes across all pages