### PR TITLE
chore: add concurrency group to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,10 @@ on:
         type: string
         default: ''
 
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write


### PR DESCRIPTION
Prevent overlapping deployments when multiple merges happen in quick succession. New merge cancels in-progress deploy.