### PR TITLE
fix: use API route for version endpoint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,7 +144,7 @@ jobs:
           echo "🔍 Verifying deployment..."
           EXPECTED="${{ github.sha }}"
           for i in $(seq 1 30); do
-            LIVE_COMMIT=$(curl -sf "https://diffractwd.com/version.json" 2>/dev/null | jq -r '.commit // empty') || true
+            LIVE_COMMIT=$(curl -sf "https://diffractwd.com/api/version" 2>/dev/null | jq -r '.commit // empty') || true
             if [ "$LIVE_COMMIT" = "$EXPECTED" ]; then
               echo "✅ Deployment verified! Live commit: $LIVE_COMMIT"
               echo "deployment-status=success" >> $GITHUB_OUTPUT

--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'fs';
+import { NextResponse } from 'next/server';
+
+let versionInfo: Record<string, string> = {};
+try {
+  versionInfo = JSON.parse(readFileSync('./public/version.json', 'utf-8'));
+} catch {
+  // version.json not available (local development)
+}
+
+export function GET() {
+  return NextResponse.json(versionInfo);
+}


### PR DESCRIPTION
## Summary
- Next.js standalone doesn't serve `public/version.json` created at build time (not in file manifest)
- Added `src/app/api/version/route.ts` — proper Next.js API route that reads version.json at startup
- Updated CI verify step to use `/api/version` instead of `/version.json`

## Test plan
- [ ] CI passes
- [ ] `curl https://diffractwd.com/api/version` returns commit info after deploy