### PR TITLE
fix: fail deploy on unverified deployment + force service update

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,7 +125,11 @@ jobs:
             # Deploy to Docker Swarm
             echo "🐳 Deploying stack..."
             docker stack deploy -c docker-compose.yml diffractwd --with-registry-auth
-            
+
+            # Force service update to ensure new image is pulled and containers restart
+            echo "🔄 Forcing service update..."
+            docker service update --force --with-registry-auth diffractwd_web
+
             # Wait for deployment
             echo "⏳ Waiting for service to be ready..."
             sleep 15
@@ -153,8 +157,8 @@ jobs:
             echo "⏳ Attempt $i/30 — got: ${LIVE_COMMIT:-no response}, want: ${EXPECTED:0:8}"
             sleep 10
           done
-          echo "⚠️ Could not verify deployment within 5 minutes"
-          echo "deployment-status=warning" >> $GITHUB_OUTPUT
+          echo "❌ Deployment verification failed — live version does not match expected commit"
+          exit 1
 
       - name: 🧹 Cleanup
         if: always()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,16 +119,24 @@ jobs:
             set -e
             cd /opt/diffractwd-com
             
+            # Authenticate with GHCR on server
+            echo "🔐 Authenticating with GHCR..."
+            echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
             # Update image tag in docker-compose
             sed -i "s|image:.*|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${IMAGE_TAG}|g" docker-compose.yml
-            
+
+            # Pull new image before deploying
+            echo "📥 Pulling image..."
+            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${IMAGE_TAG}
+
             # Deploy to Docker Swarm
             echo "🐳 Deploying stack..."
             docker stack deploy -c docker-compose.yml diffractwd --with-registry-auth
 
-            # Force service update to ensure new image is pulled and containers restart
+            # Force service update to ensure containers restart with new image
             echo "🔄 Forcing service update..."
-            docker service update --force --with-registry-auth diffractwd_web
+            docker service update --force diffractwd_web
 
             # Wait for deployment
             echo "⏳ Waiting for service to be ready..."


### PR DESCRIPTION
## Summary
- **Verification step now fails the workflow** (`exit 1`) when the live site doesn't match the expected commit — previously it silently passed with a warning, masking broken deployments
- **Added `docker service update --force`** after `docker stack deploy` to guarantee Docker Swarm pulls the new image and restarts containers

## Context
Same issue as vreshch/vreshch.com#73 — deploy workflow reported success while production stayed on an older version.

## Test plan
- [ ] Merge and verify the deploy workflow runs and the live site updates to the new commit
- [ ] Confirm `https://diffractwd.com/api/version` shows the correct commit SHA after deploy