### PR TITLE
chore: standardize dependabot — 1 PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,39 +11,9 @@ updates:
       - 'vreshch'
     open-pull-requests-limit: 10
     groups:
-      dev-dependencies:
+      all-dependencies:
         patterns:
-          - '@types/*'
-          - 'typescript'
-          - 'typescript-eslint'
-          - 'eslint*'
-          - '@eslint/*'
-          - 'prettier'
-          - 'vitest*'
-          - '@vitest/*'
-          - 'jest*'
-          - 'ts-jest'
-          - '@playwright/*'
-          - 'playwright*'
-          - '@testing-library/*'
-          - 'postcss'
-          - 'autoprefixer'
-          - '@tailwindcss/*'
-          - 'tailwindcss'
-        update-types:
-          - 'minor'
-          - 'patch'
-      next:
-        patterns:
-          - 'next'
-          - '@next/*'
-          - 'eslint-config-next'
-      react:
-        patterns:
-          - 'react'
-          - 'react-dom'
-          - '@types/react'
-          - '@types/react-dom'
+          - '*'
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
@@ -57,6 +27,11 @@ updates:
       timezone: 'Europe/Prague'
     assignees:
       - 'vreshch'
+    open-pull-requests-limit: 5
+    groups:
+      all-docker:
+        patterns:
+          - '*'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
@@ -67,3 +42,9 @@ updates:
       timezone: 'Europe/Prague'
     assignees:
       - 'vreshch'
+    open-pull-requests-limit: 5
+    groups:
+      all-actions:
+        patterns:
+          - '*'
+


### PR DESCRIPTION
## Standardize Dependabot Config

**1 PR per ecosystem** — all deps grouped with `patterns: ['*']`

| Ecosystem | Grouping | Majors |
|-----------|----------|--------|
| npm | all `*` | blocked (manual review) |
| docker | all `*` | allowed |
| github-actions | all `*` | allowed |
| terraform | all `*` | allowed |

### Schedule
Weekly, Friday 18:00 Prague. Limits: npm=10, others=5.

### Why
Previous config generated ~52 individual PRs in a single Friday across repos.
Fine-grained groups + no grouping on gh-actions/docker = massive PR noise.
Now: 1 bundled PR per ecosystem per week. Review, test, merge — done.