### PR TITLE
chore: add prettier format:check to CI

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:lucide.dev)",
+      "WebFetch(domain:tabler.io)",
+      "WebFetch(domain:unpkg.com)",
+      "WebFetch(domain:crystalmaker.com)",
+      "WebFetch(domain:www.xpowder.com)",
+      "Bash(npm run:*)",
+      "Bash(gh api:*)"
+    ]
+  }
+}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Lint code
         run: npm run lint
 
+      - name: Format check
+        run: npm run format:check
+
       - name: Build project
         run: npm run build
 


### PR DESCRIPTION
## Add Prettier Check to CI

Enforce formatting in PR validation pipeline.

### Changes
- Add `format:check` step to PR validation workflow
- Standardize `format:check` script to `prettier --check .`
- `.prettierignore` handles exclusions — no need for glob patterns

### Why
Prettier config exists but CI doesn't enforce it — unformatted code can merge.