### PR TITLE
feat: add in-progress PR validation comment

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -20,6 +20,55 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - name: Comment in progress
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const marker = '<!-- pr-validation-bot -->';
+            const body = `${marker}
+            ⏳ **PR Validation IN PROGRESS**
+
+            **Commit:** \`${{ github.event.pull_request.head.sha }}\`
+            **Branch:** \`${{ github.head_ref }}\`
+
+            **Checks:**
+            - ⏳ Dependencies
+            - ⏳ Linting
+            - ⏳ Format
+            - ⏳ Build
+            - ⏳ Docker build
+            - ⏳ E2E tests
+
+            ---
+            🔗 [View workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            ⏰ Started at: \`${new Date().toISOString()}\``;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c =>
+              c.user.login === 'github-actions[bot]' && c.body.startsWith(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+            }
+
       - name: Checkout PR code
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- Adds an in-progress comment at the start of PR validation so reviewers see current status instead of stale results while CI runs.

## Test plan
- [ ] Open a PR and verify the in-progress comment appears immediately
- [ ] Verify the final comment replaces the in-progress one