### PR TITLE
feat: add Google Analytics tracking

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { GoogleAnalytics } from '@/components/google-analytics';
 import { Navigation } from '@/components/navigation';
 import './globals.css';
 
@@ -60,6 +61,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         />
       </head>
       <body className="flex min-h-screen flex-col bg-[#f0f4f8] dark:bg-dark-bg">
+        <GoogleAnalytics />
         <Navigation />
         <main className="flex-1">{children}</main>
         <footer className="border-t border-primary/20 bg-primary py-8 dark:border-dark-border dark:bg-dark-surface">

--- a/src/components/google-analytics.tsx
+++ b/src/components/google-analytics.tsx
@@ -1,0 +1,28 @@
+import Script from 'next/script';
+
+const GA_MEASUREMENT_ID = 'G-17SR60QPS0';
+
+export function GoogleAnalytics() {
+  if (process.env.NODE_ENV !== 'production') return null;
+
+  return (
+    <>
+      <Script
+        strategy="afterInteractive"
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+      />
+      <Script
+        id="ga-init"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${GA_MEASUREMENT_ID}');
+          `,
+        }}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds GA4 measurement (`G-17SR60QPS0`) via `next/script`
- New component `src/components/google-analytics.tsx`, mounted in root layout
- Gated on `process.env.NODE_ENV === 'production'` — dev/local builds don't report

## Verification (self-checks)
- `npm run verify` — tsc + lint + build + 31 tests all green

## How to validate after merge
- Open https://diffractwd.com on a fresh tab
- Network: filter `gtag/js` — script should load
- GA Realtime (analytics.google.com → diffractwd.com property → Realtime) should show 1 active user within ~30s