### PR TITLE
chore(seo): add twitter card metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,6 +31,13 @@ export const metadata: Metadata = {
       { url: '/hero.jpg', width: 1200, height: 630, alt: 'DiffractWD application screenshot' },
     ],
   },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'DiffractWD - Free Powder Diffraction Software',
+    description:
+      'Free open-source software for powder diffraction pattern manipulation, simulation, and visualization.',
+    images: ['/hero.jpg'],
+  },
   alternates: {
     canonical: '/',
   },


### PR DESCRIPTION
## Summary

- `openGraph` already has the 1200×630 `/hero.jpg`
- Adds matching `twitter` metadata (card: summary_large_image, images: ['/hero.jpg']) so X renders the full card instead of a generic preview

## Test plan

- [ ] X card validator shows hero
- [ ] LinkedIn / Slack previews unchanged