### PR TITLE
fix(ci): deploy summary reads commit message via env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -183,13 +183,15 @@ jobs:
     steps:
       - name: 📊 Generate summary
         uses: actions/github-script@v9
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         with:
           script: |
             const buildResult = '${{ needs.build-and-push.result }}';
             const deployResult = '${{ needs.deploy.result }}';
             const imageTag = '${{ needs.build-and-push.outputs.image-tag }}';
             const commitSha = '${{ github.sha }}';
-            const commitMessage = `${{ github.event.head_commit.message }}` || 'Manual deployment';
+            const commitMessage = process.env.COMMIT_MESSAGE || 'Manual deployment';
             const eventName = '${{ github.event_name }}';
             const triggerType = eventName === 'workflow_dispatch' ? 'Manual' : 'Automatic (push)';
 


### PR DESCRIPTION
The Deploy-to-Production summary step interpolated `${{ github.event.head_commit.message }}` raw into a JS template literal. The dependabot squash-merge commit body contains backticks, which closed the template literal early and exposed version numbers as bare JS -> `SyntaxError: Unexpected number`, failing the summary job (the actual Build + Deploy succeeded). Fixes the red run on master and closes a script-injection vector by reading the message from an env var.